### PR TITLE
Improve handling of curves

### DIFF
--- a/round_corners.py
+++ b/round_corners.py
@@ -818,8 +818,40 @@ def intersectCenterCurveSegments(segment1, segment2):
   searchValues = segment1.convexHullSearchValues(segment2._searchDir)
   if segment2._searchValues[1] < searchValues[0] or segment2._searchValues[0] > searchValues[1] or segment2._searchValues[3] < searchValues[2] or segment2._searchValues[2] > searchValues[3]:
     return None
+  
+  if segment1._terminalSegments == 1 and segment2._terminalSegments == 1:
+    # nothing to divide here anymore. Just calculate the time of the intersection of the lines
+    a11 = segment1._p_end[0] - segment1._p_start[0]
+    a21 = segment1._p_end[1] - segment1._p_start[1]
+    a12 = segment2._p_start[0] - segment2._p_end[0]
+    a22 = segment2._p_start[1] - segment2._p_end[1]
+    b1 = segment2._p_start[0] - segment1._p_start[0]
+    b2 = segment2._p_start[1] - segment1._p_start[1]
+    det = a11*a22 - a21*a12
+    print(segment1._t_start, segment1._t_end)
+    if det != 0.:
+      t1 = (a22*b1 - a12*b2)/det
+      t2 = (-a21*b1 + a11*b2)/det
+      return (
+        (1-t1) * segment1._t_start + t1 * segment1._t_end,
+        (1-t2) * segment2._t_start + t2 * segment2._t_end,
+      )
+    else:
+      # TODO: Implement det = 0 case
+      raise Exception("det = 0 case not implemented yet")
 
-  return (0, 0)
+  subSegments1 = segment1._segments if segment1._terminalSegments > 1 else [segment1]
+  # reverse as we want to find the last matching for segment1
+  subSegments1.reverse()
+  subSegments2 = segment2._segments if segment2._terminalSegments > 1 else [segment2]
+
+  for s1 in subSegments1:
+    for s2 in subSegments2:
+      ret = intersectCenterCurveSegments(s1, s2)
+      if ret is not None:
+        return ret
+
+  return None
 
 if __name__ == '__main__':
     RoundedCorners().run()

--- a/round_corners.py
+++ b/round_corners.py
@@ -438,55 +438,6 @@ class RoundedCorners(inkex.EffectExtension):
       next = { 'idx': next_idx, 'dir':dir2, 'handle':handle2 }
       sn = { 'idx': node_idx, 'prev': prev, 'next': next, 'x': t[1][0], 'y': t[1][1] }
 
-      if dist1 < self.radius:
-        if debug:
-          print("subpath node_idx=%d, dist to prev(%d) is smaller than radius: %g < %g" %
-                (node_idx, prev_idx, dist1, self.radius), file=sys.stderr)
-          pprint.pprint(sn, stream=sys.stderr)
-        if self.skipped_small_len > dist1: self.skipped_small_len = dist1
-        self.skipped_small_count += 1
-        return None, None
-
-      if dist2 < self.radius:
-        if debug:
-          print("subpath node_idx=%d, dist to next(%d) is smaller than radius: %g < %g" %
-                (node_idx, next_idx, dist2, self.radius), file=sys.stderr)
-          pprint.pprint(sn, stream=sys.stderr)
-        if self.skipped_small_len > dist2: self.skipped_small_len = dist2
-        self.skipped_small_count += 1
-        return None, None
-
-      len_h1 = math.sqrt(handle1[0]*handle1[0] + handle1[1]*handle1[1])
-      len_h2 = math.sqrt(handle2[0]*handle2[0] + handle2[1]*handle2[1])
-      prev['hlen'] = len_h1
-      next['hlen'] = len_h2
-
-      if len_h1 < self.radius:
-        if debug:
-          print("subpath node_idx=%d, handle to prev(%d) is shorter than radius: %g < %g" %
-                (node_idx, prev_idx, len_h1, self.radius), file=sys.stderr)
-          pprint.pprint(sn, stream=sys.stderr)
-        if self.skipped_small_len > len_h1: self.skipped_small_len = len_h1
-        self.skipped_small_count += 1
-        return None, None
-      if len_h2 < self.radius:
-        if debug:
-          print("subpath node_idx=%d, handle to next(%d) is shorter than radius: %g < %g" %
-                (node_idx, next_idx, len_h2, self.radius), file=sys.stderr)
-          pprint.pprint(sn, stream=sys.stderr)
-        if self.skipped_small_len > len_h2: self.skipped_small_len = len_h2
-        self.skipped_small_count += 1
-        return None, None
-
-      if len_h1 > dist1: # shorten that handle to dist1, avoid overshooting the point
-        handle1[0] = handle1[0] * dist1 / len_h1
-        handle1[1] = handle1[1] * dist1 / len_h1
-        prev['hlen'] = dist1
-      if len_h2 > dist2: # shorten that handle to dist2, avoid overshooting the point
-        handle2[0] = handle2[0] * dist2 / len_h2
-        handle2[1] = handle2[1] * dist2 / len_h2
-        next['hlen'] = dist2
-
       return sn, sp_node_idx_
 
 

--- a/test/test_CenterCurveSegment.py
+++ b/test/test_CenterCurveSegment.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # coding=utf-8
 
+import math
 from inkex.tester import TestCase
-from round_corners import CenterCurveSegment
+from round_corners import CenterCurveSegment, intersectCenterCurveSegments
 
 class CenterCurveTestCase(TestCase):
     def test_point_calculation(self):
-        ccs = CenterCurveSegment(
+        s = CenterCurveSegment(
             [-1, 1, -1, 1],
             [-1, -1, 1, 1],
             1,
@@ -15,6 +16,36 @@ class CenterCurveTestCase(TestCase):
             0,
             1
         )
-        self.assertAlmostEqual(ccs.p_start, (-1, -0.5))
-        self.assertAlmostEqual(ccs.p_end, (1, 1.5))
-        self.assertAlmostEqual(ccs.calculate_center_point(0.5), (-0.5, 0))
+        self.assertAlmostEqual(s._p_start, (-1, -0.5))
+        self.assertAlmostEqual(s._p_end, (1, 1.5))
+        self.assertAlmostEqual(s.calculate_center_point(0.5), (-0.5, 0))
+        self.assertLessEqual(s._terminalSegments, 30)
+        self.assertAlmostEqual(s._searchDir, (1/math.sqrt(2), 1/math.sqrt(2)))
+        self.assertLess(s._searchValues[0], -1.060)
+        self.assertGreater(s._searchValues[1], 1.767)
+        self.assertLess(s._searchValues[2], 0.092)
+        self.assertGreater(s._searchValues[3], 0.908)
+
+    def test_empty_intersection(self):
+        # the two segments are far away of each other.
+        # empty intersection should be found immediately.
+        s1 = CenterCurveSegment(
+            [-1, 1, -1, 1],
+            [-1, -1, 1, 1],
+            1,
+            0.5,
+            0.01,
+            0,
+            1
+        )
+        s2 = CenterCurveSegment(
+            [-1, 1, -1, 1],
+            [-1+5, -1+5, 1+5, 1+5],
+            1,
+            0.5,
+            0.01,
+            0,
+            1
+        )
+        ret = intersectCenterCurveSegments(s1, s2)
+        self.assertEqual(ret, None)

--- a/test/test_CenterCurveSegment.py
+++ b/test/test_CenterCurveSegment.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+from inkex.tester import TestCase
+from round_corners import CenterCurveSegment
+
+class CenterCurveTestCase(TestCase):
+    def test_point_calculation(self):
+        ccs = CenterCurveSegment(
+            [-1, 1, -1, 1],
+            [-1, -1, 1, 1],
+            1,
+            0.5,
+            0.01,
+            0,
+            1
+        )
+        self.assertAlmostEqual(ccs.p_start, (-1, -0.5))
+        self.assertAlmostEqual(ccs.p_end, (1, 1.5))
+        self.assertAlmostEqual(ccs.calculate_center_point(0.5), (-0.5, 0))

--- a/test/test_CenterCurveSegment.py
+++ b/test/test_CenterCurveSegment.py
@@ -49,3 +49,27 @@ class CenterCurveTestCase(TestCase):
         )
         ret = intersectCenterCurveSegments(s1, s2)
         self.assertEqual(ret, None)
+
+    def test_intersection(self):
+        # the two segments are far away of each other.
+        # empty intersection should be found immediately.
+        s1 = CenterCurveSegment(
+            [-1, 1, -1, 1],
+            [-1, -1, 1, 1],
+            1,
+            0.5,
+            0.01,
+            0,
+            1
+        )
+        s2 = CenterCurveSegment(
+            [1,- 1, 1, -1],
+            [-1, -1, 1, 1],
+            -1,
+            0.5,
+            0.01,
+            0,
+            1
+        )
+        ret = intersectCenterCurveSegments(s1, s2)
+        self.assertEqual(ret, (0.8261830601756845, 0.8261830601756845))


### PR DESCRIPTION
Hi @jnweiger,

some time ago, we have discussed in #8 on how the rounding process could be improved. This PR could be a first step in that direction. First of all, this PR is currently a work in progress and not yet ready to be merged. I have created this PR to start the discussion about the approach and what it takes to be ready for merging.

**what it provides**
The current implementation assumes mainly straight lines between the nodes. However, we have bezier curves there. As a result, the rounding procedure produces some strange artifacts, which are not intended.

The proposed approach splits the bezier curves into smaller segments which can be handled easier. It is basically the approach discussed in #8 . For both bezier curves next to the node to be rounded, a circle is rolled over these and the curve of the center is generated. Intersection of these gives the center point of the rounding arc.

Result:
![image](https://github.com/jnweiger/inkscape-round-corners/assets/26203080/424f2f20-ba59-4245-8166-2a3290092da0)

**current limitations**
- the current algorithm is not optimized very well. As it produces a much better result, the computational costs are higher than the simpler line based implementation.
- a lot of documentation is missing to make the approach accessible.
- more old code could be removed. Right now I was only pushing for a minimal working version
- corners with > 180° are currently not handled
- a lot of corner cases are not handled very well.
